### PR TITLE
Add check that prevents overriding steps in the back path

### DIFF
--- a/src/Controller/Component/ToolsComponent.php
+++ b/src/Controller/Component/ToolsComponent.php
@@ -36,6 +36,7 @@ class ToolsComponent extends Component
                 || ($this->request->session()->check('back_action.' . $requestedBackAction) 
                     && $this->request->session()->read('back_action.' . $requestedBackAction) != $requestedAction
                 )
+                && (!$this->request->session()->check('back_action.' . $requestedAction))
             ) {
                 $this->request->session()->write('back_action.' . $requestedAction, $requestedBackAction);
             }

--- a/src/Controller/Component/ToolsComponent.php
+++ b/src/Controller/Component/ToolsComponent.php
@@ -36,7 +36,7 @@ class ToolsComponent extends Component
                 || ($this->request->session()->check('back_action.' . $requestedBackAction) 
                     && $this->request->session()->read('back_action.' . $requestedBackAction) != $requestedAction
                 )
-                && (!$this->request->session()->check('back_action.' . $requestedAction))
+                && !$this->request->session()->check('back_action.' . $requestedAction)
             ) {
                 $this->request->session()->write('back_action.' . $requestedAction, $requestedBackAction);
             }


### PR DESCRIPTION
This commit is supposed to fix https://github.com/scherersoftware/cake-cktools/issues/2
It checks if there is already a back action for the requested action and if that is the case it won't override it.