### PR TITLE
Fix query parameters breaking in back actions

### DIFF
--- a/src/Controller/Component/ToolsComponent.php
+++ b/src/Controller/Component/ToolsComponent.php
@@ -30,10 +30,10 @@ class ToolsComponent extends Component
         }
         if (!empty($this->request->query['back_action'])) {
             $requestedBackAction = $this->request->query['back_action'];
-            $requestedAction = preg_replace('/(\\?|&)back_action=.*?(&|$)/', '', $this->request->here(false));
+            $requestedAction = $this->_getRequestedAction();
 
             if (!$this->request->session()->check('back_action.' . $requestedBackAction)
-                || ($this->request->session()->check('back_action.' . $requestedBackAction) 
+                || ($this->request->session()->check('back_action.' . $requestedBackAction)
                     && $this->request->session()->read('back_action.' . $requestedBackAction) != $requestedAction
                 )
                 && !$this->request->session()->check('back_action.' . $requestedAction)
@@ -41,5 +41,23 @@ class ToolsComponent extends Component
                 $this->request->session()->write('back_action.' . $requestedAction, $requestedBackAction);
             }
         }
+    }
+
+    /**
+     * Returns the requested action excluding the back action.
+     *
+     * @return string
+     */
+    protected function _getRequestedAction()
+    {
+        /*
+         * Remove back_action from query string but keep the `?` if it is the first query param and there are additional query params following.
+         */
+        $requestedAction = preg_replace('/back_action=.*?(&|$)/', '', $this->request->here(false));
+
+        /*
+         * If `?` is the last char in the url we can remove it.
+         */
+        return preg_replace('/\\?$/', '', $requestedAction);
     }
 }

--- a/src/View/Helper/CkToolsHelper.php
+++ b/src/View/Helper/CkToolsHelper.php
@@ -198,9 +198,9 @@ class CkToolsHelper extends Helper
         if ($this->request->is('ajax')) {
             $backAction = $this->request->referer(true);
         }
-        $backAction = preg_replace('/(\\?|&)back_action=.*?(&|$)/', '', $backAction);
+        $backAction = preg_replace('/back_action=.*?(&|$)/', '', $backAction);
 
-        $url['?']['back_action'] = $backAction;
+        $url['?']['back_action'] = preg_replace('/\\?$/', '', $backAction);
 
         return $url;
     }


### PR DESCRIPTION
If the current page is `/?page=5` and a link on the page has the href `/abc/def?back_action=<page>&page=5` the regex will replace the text which results in a back action of `/page=5`.
This fix is to fix that behaviour so that the actual back action will be `/?page=5`