### PR TITLE
Fix back button not using the correct current url

### DIFF
--- a/src/Controller/Component/ToolsComponent.php
+++ b/src/Controller/Component/ToolsComponent.php
@@ -3,61 +3,21 @@ namespace CkTools\Controller\Component;
 
 use Cake\Controller\Component;
 use Cake\Event\Event;
+use CkTools\Utility\BackButtonTrait;
 
 /**
  * Tools Component
  */
 class ToolsComponent extends Component
 {
+    use BackButtonTrait;
 
     /**
      * {@inheritDoc}
      */
     public function beforeFilter(Event $event)
     {
-        $this->_handleBackActions();
+        $this->handleBackActions();
     }
 
-    /**
-     * persists requested back actions with their context in session
-     *
-     * @return void
-     */
-    protected function _handleBackActions()
-    {
-        if (!$this->request->session()->check('back_action')) {
-            $this->request->session()->write('back_action', []);
-        }
-        if (!empty($this->request->query['back_action'])) {
-            $requestedBackAction = $this->request->query['back_action'];
-            $requestedAction = $this->_getRequestedAction();
-
-            if (!$this->request->session()->check('back_action.' . $requestedBackAction)
-                || ($this->request->session()->check('back_action.' . $requestedBackAction)
-                    && $this->request->session()->read('back_action.' . $requestedBackAction) != $requestedAction
-                )
-                && !$this->request->session()->check('back_action.' . $requestedAction)
-            ) {
-                $this->request->session()->write('back_action.' . $requestedAction, $requestedBackAction);
-            }
-        }
-    }
-
-    /**
-     * Returns the requested action excluding the back action.
-     *
-     * @return string
-     */
-    protected function _getRequestedAction()
-    {
-        /*
-         * Remove back_action from query string but keep the `?` if it is the first query param and there are additional query params following.
-         */
-        $requestedAction = preg_replace('/back_action=.*?(&|$)/', '', $this->request->here(false));
-
-        /*
-         * If `?` is the last char in the url we can remove it.
-         */
-        return preg_replace('/\\?$/', '', $requestedAction);
-    }
 }

--- a/src/Utility/BackButtonTrait.php
+++ b/src/Utility/BackButtonTrait.php
@@ -1,0 +1,72 @@
+<?php
+namespace CkTools\Utility;
+
+/**
+ * This trait provides functionality for back buttons.
+ */
+trait BackButtonTrait {
+
+    /**
+     * Returns the requested action excluding the back action.
+     *
+     * @return string
+     */
+    public function getRequestedAction()
+    {
+        /*
+         * Remove back_action from query string but keep the `?` if it is the first query param and there are additional query params following.
+         */
+        $requestedAction = preg_replace('/back_action=.*?(&|$)/', '', $this->request->here(false));
+
+        /*
+         * If `?` is the last char in the url we can remove it.
+         */
+        return preg_replace('/\\?$/', '', $requestedAction);
+    }
+
+
+    /**
+     * persists requested back actions with their context in session
+     *
+     * @return void
+     */
+    public function handleBackActions()
+    {
+        if (!$this->request->session()->check('back_action')) {
+            $this->request->session()->write('back_action', []);
+        }
+        if (!empty($this->request->query['back_action'])) {
+            $requestedBackAction = $this->request->query['back_action'];
+            $requestedAction = $this->getRequestedAction();
+
+            if (!$this->request->session()->check('back_action.' . $requestedBackAction)
+                || ($this->request->session()->check('back_action.' . $requestedBackAction)
+                    && $this->request->session()->read('back_action.' . $requestedBackAction) != $requestedAction
+                )
+                && !$this->request->session()->check('back_action.' . $requestedAction)
+            ) {
+                $this->request->session()->write('back_action.' . $requestedAction, $requestedBackAction);
+            }
+        }
+    }
+
+
+    /**
+     * Adds a back action get param to an url array
+     *
+     * @param array $url URL array
+     * @return array
+     */
+    public function augmentUrlByBackParam(array $url)
+    {
+        $backAction = $this->request->here(false);
+        if ($this->request->is('ajax')) {
+            $backAction = $this->request->referer(true);
+        }
+        $backAction = preg_replace('/back_action=.*?(&|$)/', '', $backAction);
+
+        $url['?']['back_action'] = preg_replace('/\\?$/', '', $backAction);
+
+        return $url;
+    }
+}

--- a/src/View/Helper/CkToolsHelper.php
+++ b/src/View/Helper/CkToolsHelper.php
@@ -351,7 +351,7 @@ class CkToolsHelper extends Helper
             $title = '<span class="button-text">' . __('Back') . '</span>';
         }
 
-        $here = preg_replace('/(\\?|&)back_action=.*?(&|$)/', '', $this->request->here(false));
+        $here = $this->_getRequestedAction();
         if ($this->request->session()->check('back_action.' . $here)) {
             $url = $this->request->session()->read('back_action.' . $here);
         }
@@ -362,6 +362,24 @@ class CkToolsHelper extends Helper
         }
 
         return $this->button($title, $url, $options);
+    }
+
+    /**
+     * Returns the requested action excluding the back action.
+     *
+     * @return string
+     */
+    protected function _getRequestedAction()
+    {
+        /*
+         * Remove back_action from query string but keep the `?` if it is the first query param and there are additional query params following.
+         */
+        $requestedAction = preg_replace('/back_action=.*?(&|$)/', '', $this->request->here(false));
+
+        /*
+         * If `?` is the last char in the url we can remove it.
+         */
+        return preg_replace('/\\?$/', '', $requestedAction);
     }
 
     /**

--- a/src/View/Helper/CkToolsHelper.php
+++ b/src/View/Helper/CkToolsHelper.php
@@ -7,9 +7,12 @@ use Cake\Routing\Router;
 use Cake\Utility\Hash;
 use Cake\Utility\Text;
 use Cake\View\Helper;
+use CkTools\Utility\BackButtonTrait;
 
 class CkToolsHelper extends Helper
 {
+    use BackButtonTrait;
+
     public $helpers = ['Html', 'Form'];
 
     /**
@@ -187,25 +190,6 @@ class CkToolsHelper extends Helper
     }
 
     /**
-     * Adds a back action get param to an url array
-     *
-     * @param array $url URL array
-     * @return array
-     */
-    public function augmentUrlByBackParam(array $url)
-    {
-        $backAction = $this->request->here(false);
-        if ($this->request->is('ajax')) {
-            $backAction = $this->request->referer(true);
-        }
-        $backAction = preg_replace('/back_action=.*?(&|$)/', '', $backAction);
-
-        $url['?']['back_action'] = preg_replace('/\\?$/', '', $backAction);
-
-        return $url;
-    }
-
-    /**
      * Renders an add button
      *
      * @param string $title Link Caption
@@ -351,7 +335,7 @@ class CkToolsHelper extends Helper
             $title = '<span class="button-text">' . __('Back') . '</span>';
         }
 
-        $here = $this->_getRequestedAction();
+        $here = $this->getRequestedAction();
         if ($this->request->session()->check('back_action.' . $here)) {
             $url = $this->request->session()->read('back_action.' . $here);
         }
@@ -362,24 +346,6 @@ class CkToolsHelper extends Helper
         }
 
         return $this->button($title, $url, $options);
-    }
-
-    /**
-     * Returns the requested action excluding the back action.
-     *
-     * @return string
-     */
-    protected function _getRequestedAction()
-    {
-        /*
-         * Remove back_action from query string but keep the `?` if it is the first query param and there are additional query params following.
-         */
-        $requestedAction = preg_replace('/back_action=.*?(&|$)/', '', $this->request->here(false));
-
-        /*
-         * If `?` is the last char in the url we can remove it.
-         */
-        return preg_replace('/\\?$/', '', $requestedAction);
     }
 
     /**


### PR DESCRIPTION
The back button used the old regex replacement to get the current url therefore in some cases 
`$this->request->session()->check('back_action.' . $here)` returned false. 