### PR TITLE
Write html string in chunks to prevent exceeding pcre.backtrack_limit

### DIFF
--- a/src/Model/Behavior/SortableBehavior.php
+++ b/src/Model/Behavior/SortableBehavior.php
@@ -44,8 +44,8 @@ class SortableBehavior extends Behavior
     public function restoreSorting(array $scope = []): void
     {
         $records = $this->_table->find()
-            ->select($this->_table->primaryKey(), $this->config('sortField'))
-            ->order($this->config('defaultOrder'));
+            ->select($this->_table->getPrimaryKey(), $this->getConfig('sortField'))
+            ->order($this->getConfig('defaultOrder'));
         if (!empty($scope)) {
             $records->where($scope);
         }
@@ -53,9 +53,9 @@ class SortableBehavior extends Behavior
         foreach ($records as $n => $entity) {
             $sort = ($n + 1);
             $this->_table->updateAll([
-                $this->config('sortField') => $sort
+                $this->getConfig('sortField') => $sort
             ], [
-                $this->_table->primaryKey() => $entity->get($this->_table->primaryKey())
+                $this->_table->getPrimaryKey() => $entity->get($this->_table->getPrimaryKey())
             ]);
         }
     }
@@ -69,7 +69,7 @@ class SortableBehavior extends Behavior
      */
     public function beforeSave(Event $event, Entity $entity): void
     {
-        $this->__originalSortValue = $entity->getOriginal($this->config('sortField'));
+        $this->__originalSortValue = $entity->getOriginal($this->getConfig('sortField'));
     }
 
     /**
@@ -82,67 +82,67 @@ class SortableBehavior extends Behavior
     public function afterSave(Event $event, Entity $entity): void
     {
         $fields = array_merge([
-            $this->_table->primaryKey(),
-            $this->config('sortField')
-        ], $this->config('columnScope'));
-        $savedEntity = $this->_table->get($entity->get($this->_table->primaryKey()), [
+            $this->_table->getPrimaryKey(),
+            $this->getConfig('sortField')
+        ], $this->getConfig('columnScope'));
+        $savedEntity = $this->_table->get($entity->get($this->_table->getPrimaryKey()), [
             'fields' => $fields
         ]);
-        $scope = $this->config('scope');
+        $scope = $this->getConfig('scope');
 
-        foreach ($this->config('columnScope') as $column) {
+        foreach ($this->getConfig('columnScope') as $column) {
             $scope[$column] = $savedEntity->get($column);
         }
-        $entitySort = $savedEntity->{$this->config('sortField')};
-        $entityId = $entity->get($this->_table->primaryKey());
+        $entitySort = $savedEntity->{$this->getConfig('sortField')};
+        $entityId = $entity->get($this->_table->getPrimaryKey());
 
         if (empty($entitySort)) {
             $nextSortValue = $this->getNextSortValue($scope);
             $this->_table->updateAll([
-                $this->config('sortField') => $nextSortValue
+                $this->getConfig('sortField') => $nextSortValue
             ], [
-                $this->_table->primaryKey() => $entityId
+                $this->_table->getPrimaryKey() => $entityId
             ]);
         } else {
             if ($entitySort < $this->__originalSortValue) {
                 $currentScope = $scope;
-                $currentScope[] = "{$this->config('sortField')} <" . $this->__originalSortValue;
-                $currentScope[] = "{$this->config('sortField')} >=" . $entitySort;
+                $currentScope[] = "{$this->getConfig('sortField')} <" . $this->__originalSortValue;
+                $currentScope[] = "{$this->getConfig('sortField')} >=" . $entitySort;
                 $currentScope[] = [
-                    $this->_table->primaryKey() . ' !=' => $entity->id
+                    $this->_table->getPrimaryKey() . ' !=' => $entity->id
                 ];
 
                 $query = $this->_table->query()->update();
                 $query->where($currentScope);
                 $query->set([
-                    $this->config('sortField') => $query->newExpr($this->config('sortField') . ' + 1')
+                    $this->getConfig('sortField') => $query->newExpr($this->getConfig('sortField') . ' + 1')
                 ]);
                 $query->execute();
             } elseif ($entitySort > $this->__originalSortValue) {
                 $currentScope = $scope;
-                $currentScope[] = "{$this->config('sortField')} >" . $this->__originalSortValue;
-                $currentScope[] = "{$this->config('sortField')} <=" . $entitySort;
+                $currentScope[] = "{$this->getConfig('sortField')} >" . $this->__originalSortValue;
+                $currentScope[] = "{$this->getConfig('sortField')} <=" . $entitySort;
                 $currentScope[] = [
-                    $this->_table->primaryKey() . ' !=' => $entity->id
+                    $this->_table->getPrimaryKey() . ' !=' => $entity->id
                 ];
 
                 $query = $this->_table->query()->update();
                 $query->where($currentScope);
                 $query->set([
-                    $this->config('sortField') => $query->newExpr($this->config('sortField') . ' - 1')
+                    $this->getConfig('sortField') => $query->newExpr($this->getConfig('sortField') . ' - 1')
                 ]);
                 $query->execute();
             } elseif ($entitySort == $this->__originalSortValue) {
                 $currentScope = $scope;
-                $currentScope[] = "{$this->config('sortField')} >=" . $entitySort;
+                $currentScope[] = "{$this->getConfig('sortField')} >=" . $entitySort;
                 $currentScope[] = [
-                    $this->_table->primaryKey() . ' !=' => $entity->id
+                    $this->_table->getPrimaryKey() . ' !=' => $entity->id
                 ];
 
                 $query = $this->_table->query()->update();
                 $query->where($currentScope);
                 $query->set([
-                    $this->config('sortField') => $query->newExpr($this->config('sortField') . ' + 1')
+                    $this->getConfig('sortField') => $query->newExpr($this->getConfig('sortField') . ' + 1')
                 ]);
                 $query->execute();
             }
@@ -159,14 +159,14 @@ class SortableBehavior extends Behavior
     public function getNextSortValue(array $scope = []): int
     {
         $query = $this->_table->query();
-        $scope = Hash::merge($this->config('scope'), $scope);
+        $scope = Hash::merge($this->getConfig('scope'), $scope);
         if (!empty($scope)) {
             $query->where($scope);
         }
         $query->select([
-            'maxSort' => $query->func()->max($this->config('sortField'))
+            'maxSort' => $query->func()->max($this->getConfig('sortField'))
         ]);
-        $res = $query->hydrate(false)->first();
+        $res = $query->enableHydration(false)->first();
         if (empty($res)) {
             return 1;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -35,8 +35,9 @@ Configure::write('App', [
         'templates' => [ROOT . 'App' . DS . 'Template' . DS]
     ]
 ]);
+Configure::write('Error.errorLevel', E_ALL & ~E_USER_DEPRECATED);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -52,4 +53,4 @@ Cache::config([
 if (!getenv('db_dsn')) {
     putenv('db_dsn=sqlite:///:memory:');
 }
-ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
+ConnectionManager::setConfig('test', ['url' => getenv('db_dsn')]);


### PR DESCRIPTION
Long PDFs trigger the `pcre.backtrack_limit` which effectively limits the length of the string given to `$mpdf->WriteHtml()` to 1.000.000 characters. This includes any CSS as well as HTML given to this function at one call. This is a known issue of mpdf as documented in their own [documentation](https://mpdf.github.io/troubleshooting/known-issues.html#blank-pages-or-some-sections-missing)

As this limit does make sense in general to prevent endless backtrack loops because of bad regular expression, I hereby suggest limiting the HTML which is written at once according to the `pcre.backtrack_limit` set on the system minus 10% head space.
Also this approach does scale better than increasing the `pcre.backtrack_limit` to an arbitrary bigger number and hoping that no PDF ever will be bigger than that.