### PR TITLE
Prevent moxiemanager from sending incorrect Http responses

### DIFF
--- a/src/Lib/moxiemanager/classes/Http/Response.php
+++ b/src/Lib/moxiemanager/classes/Http/Response.php
@@ -50,6 +50,7 @@ class MOXMAN_Http_Response {
 	 */
 	public function sendContent($content) {
 		echo $content;
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
Prevent moxiemanager from sending incorrect Http responses/too many headers by adding an `exit;` after the Response.php's `echo $content;`