### PR TITLE
Fix PdfGenerator InvalidArgumentException

### DIFF
--- a/src/Lib/PdfGenerator.php
+++ b/src/Lib/PdfGenerator.php
@@ -197,8 +197,10 @@ class PdfGenerator
             case self::TARGET_BINARY:
                 return $mpdf->Output('', 'S');
                 break;
+            default:
+                throw new \InvalidArgumentException("{$options['target']} is not a valid target");
+                break;
         }
 
-        throw new \InvalidArgumentException("{$options['target']} is not a valid target");
     }
 }

--- a/src/Lib/PdfGenerator.php
+++ b/src/Lib/PdfGenerator.php
@@ -201,6 +201,5 @@ class PdfGenerator
                 throw new \InvalidArgumentException("{$options['target']} is not a valid target");
                 break;
         }
-
     }
 }


### PR DESCRIPTION
Move the exception into the switch statement default clause so it will not get triggered when $mpdf->Output is called without return.