### PR TITLE
Add a target to return the HTML string instead of PDF content

### DIFF
--- a/src/Lib/PdfGenerator.php
+++ b/src/Lib/PdfGenerator.php
@@ -29,6 +29,9 @@ class PdfGenerator
     // Will return the rendered PDF's binary data
     const TARGET_BINARY = 'binary';
 
+    // Will return the hydrated HTML string before rendering it to PDF
+    const TARGET_HTML = 'html';
+
     // Will download the file to the browser
     const TARGET_DOWNLOAD = 'download';
 
@@ -193,6 +196,9 @@ class PdfGenerator
                 break;
             case self::TARGET_FILE:
                 $mpdf->Output($options['filename'], 'F');
+                break;
+            case self::TARGET_HTML:
+                return $wholeString ?? '';
                 break;
             case self::TARGET_BINARY:
                 return $mpdf->Output('', 'S');


### PR DESCRIPTION
We'd like to have a simple way to compare expected HTML to actual HTML for magicplan. I did not find a way to get the HTML from mPdf so I figured it would be easiest to just use a separate target and return it 🤷🏼 